### PR TITLE
[WIP] Removes skinfer dependency.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-; envlist = py26, py27, py33, py34
-envlist = py27
+envlist = py26, py27, py33, py34
 
 [testenv]
 setenv =


### PR DESCRIPTION
Without skinfer, tests are more difficult to read (let's face it, schema is a complex object). So, I wonder if it wouldn't be better to have skinfer python3 support, and leave the dependency on tests.
